### PR TITLE
Make the project compile on Linux

### DIFF
--- a/src/SPETS/GUI/HubWindowDropTarget.h
+++ b/src/SPETS/GUI/HubWindowDropTarget.h
@@ -1,6 +1,9 @@
 #pragma once
 
-#include <wxinclude.h>
+#include <wx/wx.h>
+#include <wx/dnd.h>    // Required for wxDropTarget and wxDragResult
+#include <wx/msgdlg.h> // Common for DnD feedback
+
 
 namespace SPETS {
 

--- a/src/SPETS/Util.cpp
+++ b/src/SPETS/Util.cpp
@@ -1,25 +1,59 @@
 #include "Util.h"
 
-#include <Windows.h>
-#include <shlobj.h>
+#ifdef _WIN32
+    #include <Windows.h>
+    #include <shlobj.h>
+    #pragma comment(lib, "shell32.lib")
+    #pragma comment(lib, "Ole32.lib")
+#else
+    #include <cstdlib>
+    #include <pwd.h>
+    #include <unistd.h>
+#endif
 
-#pragma comment(lib, "shell32.lib")
-#pragma comment(lib, "Ole32.lib")
-
-std::filesystem::path SPETS::getFolderPath( const KNOWNFOLDERID& _id )
+#ifdef _WIN32
+std::filesystem::path SPETS::getFolderPath(const KNOWNFOLDERID& _id)
 {
-	wchar_t* wpath = nullptr;
-	if ( SHGetKnownFolderPath( _id, 0, NULL, &wpath ) != S_OK )
-	{
-		CoTaskMemFree( static_cast<void*>( wpath ) );
-		return "";
-	}
+    wchar_t* wpath = nullptr;
+    if (SHGetKnownFolderPath(_id, 0, NULL, &wpath) != S_OK)
+    {
+        if (wpath) CoTaskMemFree(static_cast<void*>(wpath));
+        return "";
+    }
 
-	std::wstringstream stream;
-	stream << wpath;
-
-	std::filesystem::path path = wpath;
-	CoTaskMemFree( static_cast<void*>( wpath ) );
-
-	return path;
+    std::filesystem::path path = wpath;
+    CoTaskMemFree(static_cast<void*>(wpath));
+    return path;
 }
+#else
+std::filesystem::path SPETS::getFolderPath(const std::string& _id) {
+    const char* home_env = std::getenv("HOME");
+    std::filesystem::path home = home_env ? home_env : getpwuid(getuid())->pw_dir;
+
+    // 1. Find the Steam Root
+    std::filesystem::path steamRoot = home / ".steam" / "debian-installation";
+    if (!std::filesystem::exists(steamRoot)) {
+        steamRoot = home / ".local" / "share" / "Steam";
+    }
+
+    // 2. Point to the Sprocket Proton Prefix (AppID 1674170)
+    std::filesystem::path pfxRoot = steamRoot / "steamapps" / "compatdata" / "1674170" / "pfx" / "drive_c" / "users" / "steamuser";
+
+    // 3. Handle the specific redirections
+    if (_id == "DOCUMENTS") {
+        return pfxRoot / "Documents"; 
+    }
+    
+    if (_id == "APPDATA_LOW") {
+        return pfxRoot / "AppData" / "LocalLow";
+    }
+
+    if (_id == "PROGRAM_FILES") {
+        return steamRoot; 
+    }
+
+    return home;
+}
+#endif
+
+

--- a/src/SPETS/Util.h
+++ b/src/SPETS/Util.h
@@ -1,12 +1,32 @@
 #pragma once
-
 #include <filesystem>
-#include <shlobj.h>
+#include <string>
+
+#ifdef _WIN32
+    #include <shlobj.h>
+#else
+    // Define dummy types so the Linux compiler doesn't crash on Windows GUID names
+    typedef std::string KNOWNFOLDERID;
+    #define FOLDERID_ProgramFilesX86 "PROGRAM_FILES"
+    #define FOLDERID_Documents "DOCUMENTS"
+    #define FOLDERID_LocalAppDataLow "APPDATA_LOW"
+#endif
 
 namespace SPETS {
+    inline const std::string VERSION_STR = "1.0.0";
 
-constexpr const char* VERSION_STR = "2.0";
+    //New Helper
+    inline std::filesystem::path getExecutableDir() {
+#ifdef _WIN32
+        wchar_t path[MAX_PATH];
+        GetModuleFileNameW(NULL, path, MAX_PATH);
+        return std::filesystem::path(path).parent_path();
+#else
+        // On Linux, this points to where the 'SPETS' binary actually lives
+        return std::filesystem::read_symlink("/proc/self/exe").parent_path();
+#endif
+    }
 
-std::filesystem::path getFolderPath( const KNOWNFOLDERID& _id );
-
+    std::filesystem::path getFolderPath(const KNOWNFOLDERID& _id);
 }
+

--- a/src/Sprocket/CustomBattle.cpp
+++ b/src/Sprocket/CustomBattle.cpp
@@ -31,7 +31,14 @@ void Sprocket::TeamDefinition::addUnits( int _count, const std::string& _faction
 
 Sprocket::CustomBattleConfig Sprocket::getCustomBattleSetup()
 {
-	std::filesystem::path appdata = SPETS::getFolderPath( FOLDERID_LocalAppDataLow );
+
+#ifdef _WIN32
+    std::filesystem::path appdata = SPETS::getFolderPath( FOLDERID_LocalAppDataLow );
+#else
+    // On Linux, "AppDataLow" usually maps to ~/.local/share or ~/.config
+    std::filesystem::path appdata = SPETS::getFolderPath( "APPDATA" ); 
+#endif
+
 	std::filesystem::path path = appdata / "HD" / "Sprocket" / "CustomBattleSetup.json";
 
 	std::ifstream f( path );
@@ -44,7 +51,13 @@ Sprocket::CustomBattleConfig Sprocket::getCustomBattleSetup()
 
 void Sprocket::saveCustomBattleSetup( const CustomBattleConfig& _info )
 {
-	std::filesystem::path appdata = SPETS::getFolderPath( FOLDERID_LocalAppDataLow );
+
+#ifdef _WIN32
+    std::filesystem::path appdata = SPETS::getFolderPath( FOLDERID_LocalAppDataLow );
+#else
+    // On Linux, "AppDataLow" usually maps to ~/.local/share or ~/.config
+    std::filesystem::path appdata = SPETS::getFolderPath( "APPDATA" );
+#endif
 	std::filesystem::path path = appdata / "HD" / "Sprocket" / "CustomBattleSetup.json";
 
 	std::ofstream f( path );

--- a/src/Sprocket/Error.h
+++ b/src/Sprocket/Error.h
@@ -18,4 +18,7 @@ size_t dumpErrors();
 
 }
 
-#define SPROCKET_PUSH_ERROR( ... ) Sprocket::pushError( std::format( __FUNCTION__ "({}) : {}", __LINE__, std::format( __VA_ARGS__ ) ) )
+// Corrected for cross-platform (GCC and MSVC)
+#define SPROCKET_PUSH_ERROR( ... ) \
+    Sprocket::pushError( std::format( "{} ({}) : {}", __FUNCTION__, __LINE__, std::format( __VA_ARGS__ ) ) )
+

--- a/src/Sprocket/IntermediateMesh.cpp
+++ b/src/Sprocket/IntermediateMesh.cpp
@@ -10,8 +10,20 @@
 
 bool Sprocket::createIntermediateMeshFromFile( const std::filesystem::path& _path, IntermediateMesh& _out )
 {
+
+    if (!std::filesystem::exists(_path)) {
+        SPROCKET_PUSH_ERROR( "File not found at: {}", std::filesystem::absolute(_path).string() );
+        return false;
+    }
+
 	Assimp::Importer importer;
 	const aiScene* scene = importer.ReadFile( _path.string(), aiProcess_JoinIdenticalVertices);
+
+    if ( scene == nullptr ) {
+        // Assimp-specific error message
+        SPROCKET_PUSH_ERROR( "Assimp Error: {}", importer.GetErrorString() );
+        return false;
+    }
 
 	if ( scene == nullptr || scene->mNumMeshes == 0 )
 	{

--- a/src/Sprocket/IntermediateMesh.h
+++ b/src/Sprocket/IntermediateMesh.h
@@ -4,6 +4,7 @@
 
 #include <vector>
 #include <filesystem>
+#include <cmath>
 
 namespace Sprocket {
 

--- a/src/Sprocket/PlateMesh/PlateMesh.h
+++ b/src/Sprocket/PlateMesh/PlateMesh.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <vector>
 #include <string>
 #include <stdexcept>

--- a/src/Sprocket/PlateMesh/Rivets.h
+++ b/src/Sprocket/PlateMesh/Rivets.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <vector>
 
 namespace Sprocket {

--- a/src/Sprocket/Sprocket.cpp
+++ b/src/Sprocket/Sprocket.cpp
@@ -17,8 +17,9 @@
 
 std::filesystem::path Sprocket::getStreamingAssetsPath()
 {
-	std::filesystem::path programFiles = SPETS::getFolderPath( FOLDERID_ProgramFilesX86 );
-	return programFiles / "Steam" / "steamapps" / "common" / "Sprocket" / "Sprocket_Data" / "StreamingAssets";
+    std::filesystem::path steamRoot = SPETS::getFolderPath(FOLDERID_ProgramFilesX86);
+    
+    return steamRoot / "steamapps" / "common" / "Sprocket" / "Sprocket_Data" / "StreamingAssets";
 }
 
 std::filesystem::path Sprocket::getSprocketDataPath()
@@ -81,22 +82,24 @@ bool Sprocket::doesBlueprintExist( const std::string& _faction, const std::strin
 
 bool Sprocket::createCompartmentFromMesh( const std::string& _path, MeshData& _outMesh, ImportMeshFlags _flags )
 {
-	Sprocket::IntermediateMesh immesh;
-	
-	if ( !Sprocket::createIntermediateMeshFromFile( _path, immesh ) )
-		return false;
+    std::filesystem::path resolvedPath = _path;
 
-	immesh.mergeDuplicateVertices();
+    Sprocket::IntermediateMesh immesh;
 
-	int flips = 0;
-	if ( _flags & ImportMeshFlags_FlipX ) { immesh.flipX(); flips++; }
-	if ( _flags & ImportMeshFlags_FlipY ) { immesh.flipY(); flips++; }
-	if ( _flags & ImportMeshFlags_FlipZ ) { immesh.flipZ(); flips++; }
+    if ( !Sprocket::createIntermediateMeshFromFile( resolvedPath, immesh ) )
+        return false;
 
-	if ( flips == 1 || flips == 3 )
-		immesh.reverseWindingOrder();
+    immesh.mergeDuplicateVertices();
 
-	return immesh.createCompartment( _outMesh );
+    int flips = 0;
+    if ( _flags & ImportMeshFlags_FlipX ) { immesh.flipX(); flips++; }
+    if ( _flags & ImportMeshFlags_FlipY ) { immesh.flipY(); flips++; }
+    if ( _flags & ImportMeshFlags_FlipZ ) { immesh.flipZ(); flips++; }
+
+    if ( flips == 1 || flips == 3 )
+        immesh.reverseWindingOrder();
+
+    return immesh.createCompartment( _outMesh );
 }
 
 bool Sprocket::loadBlueprint( const std::string& _faction, const std::string& _name, VehicleBlueprint& _out )

--- a/src/wxinclude.h
+++ b/src/wxinclude.h
@@ -1,5 +1,11 @@
 #pragma once
 
-#include <msvc/wx/setup.h>
+// On Windows/MSVC, this handles the auto-linking magic
+#ifdef _WIN32
+    #include <msvc/wx/setup.h>
+#endif
+
+// This is the standard way to get wxWidgets definitions portably
+#include <wx/defs.h> 
 #include <wx/wx.h>
-#include <wx/dnd.h>
+

--- a/tools/dae_prep.py
+++ b/tools/dae_prep.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+import os, re, sys, subprocess, shutil, tempfile
+
+# --- SPETS DAE Prep ---
+# Use a combination of XML syntax cleanup and blender sanitizing
+# to make sure everything is clean and ready for import into SPETS
+
+# --- CONFIGURATION ---
+# Blender dropped native Collada functions after the 4.5 branch
+# Install it on your system and give the path to the binary here
+BLENDER_PATH = "/opt/blender-4.5/blender"
+
+def stage_1_xml_scrub(filepath):
+    print(f"[*] Stage 1: Scrubbing XML syntax: {os.path.basename(filepath)}")
+    with open(filepath, 'r', encoding='utf-8', errors='ignore') as f:
+        xml = f.read()
+
+    # Kill unneeded attributes and blocks
+    xml = re.sub(r'\s+opaque="(RGB_ONE|A_ONE)"', '', xml)
+    for block in ['library_images', 'library_materials', 'library_effects', 
+                  'library_controllers', 'library_animations', 'extra']:
+        xml = re.sub(f'<{block}>.*?</{block}>', f'<{block}/>', xml, flags=re.DOTALL)
+
+    # Strip material bindings
+    xml = re.sub(r'<instance_material.*?>', '', xml)
+    xml = re.sub(r'<bind_material>.*?</bind_material>', '', xml, flags=re.DOTALL)
+
+    tmp_fd, tmp_path = tempfile.mkstemp(suffix=".dae")
+    with os.fdopen(tmp_fd, 'w') as f:
+        f.write(xml)
+    return tmp_path
+
+def stage_2_blender_repair(input_dae, output_dae):
+    print("[*] Stage 2: Repairing geometry with Blender 4.5...")
+    
+    # Corrected collada_export for Blender 4.5 API
+    py_cmd = f"""
+import bpy, sys
+try:
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+    bpy.ops.wm.collada_import(filepath=r'{input_dae}', import_units=False)
+    
+    meshes = [o for o in bpy.context.scene.objects if o.type == 'MESH']
+    if meshes:
+        bpy.ops.object.select_all(action='DESELECT')
+        for obj in meshes:
+            obj.select_set(True)
+        bpy.context.view_layer.objects.active = meshes[0]
+        
+        # Geometry Cleanup
+        bpy.ops.object.mode_set(mode='EDIT')
+        bpy.ops.mesh.select_all(action='SELECT')
+        bpy.ops.mesh.remove_doubles(threshold=0.0001)
+        bpy.ops.mesh.normals_make_consistent(inside=False)
+        bpy.ops.object.mode_set(mode='OBJECT')
+    
+    # Export - Fixed parameters for 4.5 LTS
+    # Note: 'include_animations=False' often strips the junk effectively
+    bpy.ops.wm.collada_export(
+        filepath=r'{output_dae}', 
+        apply_modifiers=True,
+        include_animations=False,
+        selected=False
+    )
+    print("PYTHON_FINISH_SUCCESS")
+except Exception as e:
+    import traceback
+    print(f"BLENDER_PY_ERROR: {{e}}")
+    traceback.print_exc()
+    sys.exit(1)
+"""
+    try:
+        proc = subprocess.run([BLENDER_PATH, "--background", "--python-expr", py_cmd], 
+                              capture_output=True, text=True)
+        if "PYTHON_FINISH_SUCCESS" in proc.stdout:
+            for line in proc.stdout.splitlines():
+                if "Removed" in line: print(f"    [+] {line.strip()}")
+            return True
+        print(f"[!] Blender Logic Error:\n{proc.stdout}\n{proc.stderr}")
+        return False
+    except Exception as e:
+        print(f"[!] Subprocess Error: {e}")
+        return False
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: ./dae_prep.py <file.dae>")
+        sys.exit(1)
+
+    target_file = os.path.abspath(sys.argv[1])
+    tmp_scrubbed = stage_1_xml_scrub(target_file)
+    
+    tmp_dir = tempfile.mkdtemp()
+    tmp_repaired = os.path.join(tmp_dir, "repaired.dae")
+    
+    if stage_2_blender_repair(tmp_scrubbed, tmp_repaired):
+        if os.path.exists(tmp_repaired):
+            # Final verification: is it non-zero size?
+            if os.path.getsize(tmp_repaired) > 0:
+                shutil.move(tmp_repaired, target_file)
+                print(f"[SUCCESS] {os.path.basename(target_file)} cleaned and overwritten.")
+    else:
+        print("[FAILURE] Cleanup failed. Original file is safe.")
+
+    if os.path.exists(tmp_scrubbed): os.remove(tmp_scrubbed)
+    shutil.rmtree(tmp_dir, ignore_errors=True)
+
+if __name__ == "__main__":
+    main()

--- a/xmake.lua
+++ b/xmake.lua
@@ -27,8 +27,9 @@ target("SPETS")
     add_files( "src/**.cpp")
 
     if is_plat("windows") then
+        add_headerfiles{ "src/**.h", "src/**.hpp" }
         local WX_ROOT = "D:/SDK/wx/3.3.1/"
-        add_defines("__WXMSW__", "WXUSINGDLL", "_UNICODE")
+        add_defines("__WXMSW__", "WXUSINGDLL", "_UNICODE", "wxMSVC_VERSION_AUTO", "wxMSVC_VERSION_ABI_COMPAT", "NDEBUG")
         add_includedirs(WX_ROOT .. "include/", WX_ROOT .. "lib/vc14x_x64_dll/mswu/")
         add_linkdirs(WX_ROOT .. "lib/vc14x_x64_dll/")
         add_files(WX_ROOT .. "include/wx/msw/wx.rc")

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,39 +1,41 @@
 set_languages("clatest", "cxxlatest")
+add_rules("mode.debug", "mode.release")
 
-add_rules "mode.debug"
-add_rules "mode.release"
+if is_plat("linux") then
+    add_syslinks("assimp", "stdc++fs", "pthread", "dl")
+    on_config(function (target)
+        local cxxflags = os.iorun("wx-config --cxxflags"):trim()
+        target:add("cxxflags", table.unpack(string.split(cxxflags, " ")))
+        
+        local ldflags = os.iorun("wx-config --libs std,aui"):trim()
+        target:add("ldflags", table.unpack(string.split(ldflags, " ")))
+    end)
 
-add_requires("nlohmann_json", "assimp")
+    add_defines("__WXGTK__")
+else
+    add_requires("nlohmann_json", "assimp")
+end
 
-local WX_ROOT = "D:/SDK/wx/3.3.1/"
-
-target "SPETS"
-    set_kind "binary" 
-    
+target("SPETS")
+    set_kind("binary")
     add_packages("nlohmann_json", "assimp")
 
-    if is_mode("debug") then 
-        set_basename "SPETS_debug_$(arch)"    
-        set_configdir "bin/dat"
-    else
-        set_basename "SPETS"
-        set_configdir "package/bin/dat"
-    end
-        
-    add_configfiles("dat/*", {onlycopy = true})
-
-    set_targetdir "bin"
-    set_objectdir "build/obj"
+    set_targetdir("bin")
+    set_objectdir("build/obj")
     
-    add_includedirs "src/"
-    add_headerfiles{ "src/**.h", "src/**.hpp" }
+    add_includedirs("src/")
+    add_files( "src/**.cpp")
 
-    add_defines("__WXMSW__", "WXUSINGDLL", "_UNICODE", "wxMSVC_VERSION_AUTO", "wxMSVC_VERSION_ABI_COMPAT", "NDEBUG")
-    add_includedirs(WX_ROOT .. "include/", WX_ROOT .. "lib/", WX_ROOT .. "lib/vc14x_x64_dll/mswu/")
-    add_linkdirs(WX_ROOT .. "lib/vc14x_x64_dll/")
+    if is_plat("windows") then
+        local WX_ROOT = "D:/SDK/wx/3.3.1/"
+        add_defines("__WXMSW__", "WXUSINGDLL", "_UNICODE")
+        add_includedirs(WX_ROOT .. "include/", WX_ROOT .. "lib/vc14x_x64_dll/mswu/")
+        add_linkdirs(WX_ROOT .. "lib/vc14x_x64_dll/")
+        add_files(WX_ROOT .. "include/wx/msw/wx.rc")
+    end
 
-    add_files(WX_ROOT .. "include/wx/msw/wx.rc")
+    if is_plat("linux") then
+        add_packages("wxwidgets")
+        add_defines("__WXGTK__")
+    end
 
-    add_files{ "src/**.c", "src/**.cpp" }
-
-target_end()


### PR DESCRIPTION
Added a bunch of OS specific #IFDEFs and fixed headers where Linux needs implicit #includes and heavily modded the xmake.lua

I didn't regression test compilation on Windows (no windows machines at my house), so there is a chance something broke there, but I tried to leave anything Windows specific in an #IFDEF if I couldn't make it fully cross-platform with a helper function or something.

I noticed I can only import dae files that are in the SPETS folder and that I have to start the project from the SPETS folder using `./bin/SPETS` or it doesn't work properly. 

Tested with latest Blender+(https://github.com/gregdavisd/DAEBlend) and Sprocket on Steam w/Proton. Works great.

I hacked all this up last night just to the point of getting it running so there may be other issues, but I just wanted the core functionality going for some personal projects in Sprocket so I'm offering it as well for potential integration into your next release. Would make it good long-term for eg steamdecks/gabecubes or other Linux powered gaming things since Sprocket is basically perfect with Proton.
